### PR TITLE
Add remote first section in CATEGORIES.md

### DIFF
--- a/CATEGORIES.MD
+++ b/CATEGORIES.MD
@@ -56,8 +56,8 @@
 
 ## Remote First
 1. [Atlassian](https://www.atlassian.com/company/careers)
-2. [BrowserStack](https://www.browserstack.com/careers)
-3. [GitHub](https://github.com/about/careers)
-4. [Indeed](https://in.indeed.com/cmp/Indeed)
-5. [Udaan](https://careers.udaan.com/)
-6. [VMware](https://careers.vmware.com/main/)
+1. [BrowserStack](https://www.browserstack.com/careers)
+1. [GitHub](https://github.com/about/careers)
+1. [Indeed](https://in.indeed.com/cmp/Indeed)
+1. [Udaan](https://careers.udaan.com/)
+1. [VMware](https://careers.vmware.com/main/)


### PR DESCRIPTION
PR for Issue #139 

Added a remote first section for the companies allowing remote work even post pandemic, and filled in the following companies from README.md: Atlassian, GitHub, Indeed, VMWare, BrowserStack, Udaan.

**Note:**
> While I have sorted the companies alphabetically, I have not created separate sections for the alphabets like what's done in the [README.md](https://github.com/Kaustubh-Natuskar/companies-to-apply/blob/main/README.md) file. In case I am supposed to create alphabetical sections, please let me know and I'll create another PR.

## Congratulations on making a pull request!
### Please make sure you check all the items.
**Not done the following as I've edited the CATEGORIES.md file**

- [ ] The numbering of the company that you added starts with ```1```.
- [ ] You have increased the ```Total Companies Added``` count.
